### PR TITLE
Fixed typo in example ark rspecifier

### DIFF
--- a/src/doc/io.dox
+++ b/src/doc/io.dox
@@ -479,7 +479,7 @@ namespace kaldi {
 
    Typical examples of rspecifiers using a lot of options are:
    \verbatim
-     "ark:o,s,cs:-"
+     "ark,o,s,cs:-"
      "scp,p:data/my.scp"
    \endverbatim
 


### PR DESCRIPTION
Fixed: "ark:o,s,cs:-" => "ark,o,s,cs:-"